### PR TITLE
Add EtherCAT servo API and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # ethercat_motor_demo
-This is to build a demo that drives an ethercat enabled servo motor
+
+This repository provides a minimal example for driving the
+[IHSV60-30-40-48-EC-SC](https://www.alibaba.com/product-detail/IHSV60-30-40-48-EC-SC_1601039441757.html)
+EtherCAT integrated servo motor.
+
+## Requirements
+
+- Python 3.11+
+- [pysoem](https://github.com/bnjmnp/pysoem) (installed automatically via `pip`)
+- An Ethernet interface connected to the servo (e.g. `eth0`)
+
+Install dependencies:
+
+```bash
+pip install pysoem
+```
+
+## Usage
+
+`demo.py` shows a basic sequence to enable the servo and move it to a target
+position using the CiA&nbsp;402 profile position mode.
+
+```bash
+python demo.py
+```
+
+Edit the network interface name and slave position in `demo.py` if needed.
+
+## Files
+
+- `ethercat_servo.py` – simple low level API for CiA&nbsp;402 EtherCAT servos
+- `demo.py` – example script using `EthercatServo`

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,19 @@
+from ethercat_servo import EthercatServo
+import time
+
+
+def main():
+    servo = EthercatServo(ifname="eth0", slave_pos=0)
+    servo.open()
+    try:
+        servo.set_mode(1)  # profile position
+        servo.enable_operation()
+        servo.set_target_position(10000)
+        time.sleep(2)
+        print("Actual position:", servo.read_actual_position())
+    finally:
+        servo.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ethercat_servo.py
+++ b/ethercat_servo.py
@@ -1,0 +1,67 @@
+import pysoem
+import struct
+import time
+from typing import Optional
+
+
+class EthercatServo:
+    """Simple EtherCAT CiA 402 servo interface."""
+
+    CONTROL_WORD = 0x6040
+    STATUS_WORD = 0x6041
+    MODE_OF_OPERATION = 0x6060
+    MODE_OF_OPERATION_DISPLAY = 0x6061
+    TARGET_POSITION = 0x607A
+    TARGET_VELOCITY = 0x60FF
+    ACTUAL_POSITION = 0x6064
+
+    def __init__(self, ifname: str, slave_pos: int = 0) -> None:
+        self.ifname = ifname
+        self.slave_pos = slave_pos
+        self.master: Optional[pysoem.Master] = None
+        self.slave = None
+
+    def open(self) -> None:
+        """Open EtherCAT master and configure slave."""
+        self.master = pysoem.Master()
+        self.master.open(self.ifname)
+        if self.master.config_init() <= self.slave_pos:
+            raise RuntimeError("Not enough slaves found")
+        self.slave = self.master.slaves[self.slave_pos]
+        self.master.config_map()
+        self.master.state = pysoem.OP_STATE
+        self.master.write_state()
+        if self.master.state != pysoem.OP_STATE:
+            raise RuntimeError("Unable to enter OP state")
+
+    def close(self) -> None:
+        if self.master:
+            self.master.close()
+            self.master = None
+
+    def write_sdo(self, idx: int, subidx: int, val: int, size: int = 2) -> None:
+        buf = val.to_bytes(size, byteorder="little", signed=False)
+        self.slave.sdo_write(idx, subidx, buf)
+
+    def read_sdo(self, idx: int, subidx: int, size: int = 2) -> int:
+        buf = self.slave.sdo_read(idx, subidx)
+        return int.from_bytes(buf[:size], byteorder="little", signed=False)
+
+    def enable_operation(self) -> None:
+        # switch on, enable voltage, quick stop, enable operation
+        for cw in (0x06, 0x07, 0x0F):
+            self.write_sdo(self.CONTROL_WORD, 0, cw)
+            time.sleep(0.1)
+
+    def set_mode(self, mode: int) -> None:
+        self.write_sdo(self.MODE_OF_OPERATION, 0, mode, size=1)
+        time.sleep(0.05)
+
+    def set_target_position(self, pos: int) -> None:
+        self.write_sdo(self.TARGET_POSITION, 0, pos, size=4)
+
+    def set_target_velocity(self, vel: int) -> None:
+        self.write_sdo(self.TARGET_VELOCITY, 0, vel, size=4)
+
+    def read_actual_position(self) -> int:
+        return self.read_sdo(self.ACTUAL_POSITION, 0, size=4)


### PR DESCRIPTION
## Summary
- add `EthercatServo` class implementing basic CiA 402 controls
- provide `demo.py` showing how to enable the servo and move it
- update README with requirements and usage instructions

## Testing
- `black *.py`
- `python -m py_compile ethercat_servo.py demo.py`


------
https://chatgpt.com/codex/tasks/task_e_684a751f13bc8324a23a44a1e7dc59db