### PR TITLE
Fix digital output size

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ python demo.py
 Edit the network interface name and slave position in `demo.py` if needed.
 
 `release_brake()` and `enable_controller()` access the digital outputs object
-(`0x60FE`). The exact object index and bits may vary, so consult your servo's
-documentation if these helpers do not work out of the box.
+(`0x60FE`, subindex 1).  According to the included ESI file the value is a
+32‑bit unsigned integer, so the demo writes four bytes when toggling the
+control bits.  The exact object index and bit assignments may vary, so consult
+your servo's documentation if these helpers do not work out of the box.
 
 ## Files
 

--- a/ethercat_servo.py
+++ b/ethercat_servo.py
@@ -79,18 +79,18 @@ class EthercatServo:
     def release_brake(self) -> None:
         """Release the motor brake using digital outputs if available."""
         try:
-            state = self.read_sdo(self.DIGITAL_OUTPUTS, 1, size=1)
+            state = self.read_sdo(self.DIGITAL_OUTPUTS, 1, size=4)
         except Exception:
             state = 0
-        self.write_sdo(self.DIGITAL_OUTPUTS, 1, state | 0x01, size=1)
+        self.write_sdo(self.DIGITAL_OUTPUTS, 1, state | 0x01, size=4)
         time.sleep(0.05)
 
     def enable_controller(self) -> None:
         """Enable controller with Fw and Fb control bits."""
         try:
-            state = self.read_sdo(self.DIGITAL_OUTPUTS, 1, size=1)
+            state = self.read_sdo(self.DIGITAL_OUTPUTS, 1, size=4)
         except Exception:
             state = 0
-        self.write_sdo(self.DIGITAL_OUTPUTS, 1, state | self.CONTROLLER_BITS, size=1)
+        self.write_sdo(self.DIGITAL_OUTPUTS, 1, state | self.CONTROLLER_BITS, size=4)
         time.sleep(0.05)
 


### PR DESCRIPTION
## Summary
- use 32-bit access for digital outputs based on ESI
- document 32-bit digital output in README

## Testing
- `python -m py_compile ethercat_servo.py demo.py get_adapter_name.py`

------
https://chatgpt.com/codex/tasks/task_e_68501047d4408324a8085dde144076fe