### PR TITLE
Integrate hardware loop test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Build artefacts
+bin/
+obj/
+**/bin/
+**/obj/
+TestResults/
+AllureReport/
+*.zip

--- a/CodexHardwareLoop/src/HardwareInterface/DeviceController.cs
+++ b/CodexHardwareLoop/src/HardwareInterface/DeviceController.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 
 namespace HardwareInterface
 {
@@ -22,6 +26,29 @@ namespace HardwareInterface
             await Task.Delay(500); // simulate latency
             // TODO: collect real diagnostic output
             return "OK";
+        }
+
+        public async ValueTask<int> RunDemoAsync()
+        {
+            Console.WriteLine("[HW] Executing demo.py");
+            var repoDir = Path.GetDirectoryName(Repository.Discover(Directory.GetCurrentDirectory())!);
+            var psi = new ProcessStartInfo("python", Path.Combine(repoDir!, "demo.py"))
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute = false,
+                WorkingDirectory = repoDir
+            };
+            using var proc = Process.Start(psi)!;
+            string output = await proc.StandardOutput.ReadToEndAsync();
+            string error  = await proc.StandardError.ReadToEndAsync();
+            await proc.WaitForExitAsync();
+            Console.WriteLine(output);
+            if (!string.IsNullOrWhiteSpace(error))
+                Console.Error.WriteLine(error);
+
+            var m = Regex.Match(output, @"Actual position:\s*(\d+)");
+            return m.Success ? int.Parse(m.Groups[1].Value) : -1;
         }
 
         public void Dispose() => Console.WriteLine("[HW] Disconnected.");

--- a/CodexHardwareLoop/src/IntegrationTests/DeviceIntegrationTests.cs
+++ b/CodexHardwareLoop/src/IntegrationTests/DeviceIntegrationTests.cs
@@ -28,5 +28,13 @@ namespace IntegrationTests
             var result = await _device!.RunSelfTestAsync();
             Assert.That(result, Is.EqualTo("OK"), "Self‑test must return OK.");
         }
+
+        [Test]
+        [AllureTag("motion")]
+        public async Task DemoScriptReportsPosition()
+        {
+            var pos = await _device!.RunDemoAsync();
+            Assert.That(pos, Is.GreaterThanOrEqualTo(0), "demo.py should print actual position");
+        }
     }
 }

--- a/CodexHardwareLoop/src/LocalAgent/Program.cs
+++ b/CodexHardwareLoop/src/LocalAgent/Program.cs
@@ -4,7 +4,13 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Threading;
 
-const string repoPath  = @"C:\Dev\CodexHardwareLoop";
+var repoPath = Repository.Discover(Environment.CurrentDirectory);
+if (repoPath is null)
+{
+    Console.Error.WriteLine("Could not locate git repository from " + Environment.CurrentDirectory);
+    return;
+}
+repoPath = Path.GetDirectoryName(repoPath)!;
 const string remote    = "origin";
 const string branch    = "main";
 const string resultsBranchPrefix = "results/";

--- a/README.md
+++ b/README.md
@@ -35,3 +35,25 @@ your servo's documentation if these helpers do not work out of the box.
 
 - `ethercat_servo.py` – simple low level API for CiA&nbsp;402 EtherCAT servos
 - `demo.py` – example script using `EthercatServo`
+- `CodexHardwareLoop` – .NET solution for hardware-in-the-loop testing
+
+## Hardware-in-the-Loop Automation
+
+The `CodexHardwareLoop` directory contains a Visual Studio solution that
+automates running integration tests on a Windows PC attached to the servo.
+
+### Usage
+
+1. Install the .NET 8 SDK, Git and the GitHub CLI (`gh`).
+2. Open `CodexHardwareLoop.sln` in Visual Studio and run the `LocalAgent` project,
+   or execute `dotnet run --project CodexHardwareLoop/src/LocalAgent` from a
+   command prompt.
+3. The agent periodically fetches the repository. When a new commit is detected
+   you will be prompted to press <kbd>Y</kbd> to deploy and execute the
+   hardware‑in‑the‑loop tests.
+4. Test results are converted into an Allure report and pushed to a branch named
+   `results/<commit SHA>`.
+
+The included integration tests call the Python demo script to verify that the
+servo can be reached and that motion commands succeed.  Inspect the console
+output and the generated Allure report when debugging problems.


### PR DESCRIPTION
## Summary
- make LocalAgent discover repo path automatically
- add method to `DeviceController` to invoke Python demo
- add integration test for the demo script
- document the HW-in-the-loop workflow
- add gitignore for build artifacts

## Testing
- `dotnet build -c Release`
- `dotnet test src/IntegrationTests/IntegrationTests.csproj --no-build --verbosity normal` *(fails: MSB4181)*
- `python demo.py` *(fails: could not open interface)*

------
https://chatgpt.com/codex/tasks/task_e_6850145228888324a1ec9fffc72da59a