### PR TITLE
Allow commands in terms of output position

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ python demo.py
 
 Edit the network interface name and slave position in `demo.py` if needed.
 
+Use `set_target_position_after_gearbox()` when commanding positions at the
+load side of a gearbox.  Pass the desired output position and the gearbox ratio
+to let the helper translate it to a motor shaft position automatically.
+
 `release_brake()` and `enable_controller()` access the digital outputs object
 (`0x60FE`, subindex 1).  According to the included ESI file the value is a
 32‑bit unsigned integer, so the demo writes four bytes when toggling the
@@ -33,8 +37,9 @@ your servo's documentation if these helpers do not work out of the box.
 
 ## Files
 
-- `ethercat_servo.py` – simple low level API for CiA&nbsp;402 EtherCAT servos
-- `demo.py` – example script using `EthercatServo`
+ - `ethercat_servo.py` – simple low level API for CiA&nbsp;402 EtherCAT servos
+   including `set_target_position_after_gearbox()` for gear ratios
+ - `demo.py` – example script using `EthercatServo`
 - `CodexHardwareLoop` – .NET solution for hardware-in-the-loop testing
 
 ## Hardware-in-the-Loop Automation

--- a/demo.py
+++ b/demo.py
@@ -3,6 +3,7 @@ import time
 
 # Device name copied from get_adapter_name.py output
 IFNAME = r"\Device\NPF_{99F254B6-0FBF-4B4D-B9DB-F9CA300B4CCF}"  # TwinCAT-Intel PCI Ethernet Adapter (Gigabit)
+GEAR_RATIO = 30  # Example 30:1 planetary gearbox
 
 
 def main():
@@ -14,7 +15,7 @@ def main():
         servo.enable_operation()
         servo.release_brake()
         servo.enable_controller()
-        servo.set_target_position(10000)
+        servo.set_target_position_after_gearbox(10000, GEAR_RATIO)
         servo.start_motion()
         time.sleep(2)
         print("Actual position:", servo.read_actual_position())

--- a/ethercat_servo.py
+++ b/ethercat_servo.py
@@ -62,6 +62,24 @@ class EthercatServo:
     def set_target_position(self, pos: int) -> None:
         self.write_sdo(self.TARGET_POSITION, 0, pos, size=4)
 
+    def set_target_position_after_gearbox(self, output_pos: int, gear_ratio: float) -> None:
+        """Set target position in terms of output position after a gearbox.
+
+        This helper multiplies ``output_pos`` by ``gear_ratio`` and sends the
+        resulting motor shaft position to the drive.  Use it when you want to
+        command the position at the load rather than directly at the motor.
+
+        Parameters
+        ----------
+        output_pos : int
+            Desired position of the output shaft after the gearbox.
+        gear_ratio : float
+            Gear ratio (motor revolutions per output revolution).
+        """
+
+        motor_pos = int(output_pos * gear_ratio)
+        self.set_target_position(motor_pos)
+
     def set_target_velocity(self, vel: int) -> None:
         self.write_sdo(self.TARGET_VELOCITY, 0, vel, size=4)
 


### PR DESCRIPTION
## Summary
- add `set_target_position_after_gearbox()` helper for motor control with a gearbox
- demonstrate the new helper in `demo.py`
- document gearbox helper usage in README

## Testing
- `python -m py_compile ethercat_servo.py demo.py get_adapter_name.py`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501a61d0e48324bfb3101ed1452ab8