### PR TITLE
Improve adapter handling in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ pip install pysoem
 python demo.py
 ```
 
-Edit the network interface name and slave position in `demo.py` if needed.
+By default the script uses the first network adapter returned by
+`get_first_adapter()` from `get_adapter_name.py`.  You can override the adapter
+name via the `ECAT_IFNAME` environment variable or with
+`python demo.py --ifname IFNAME`.  Adjust the slave position in `demo.py` if
+needed.
 
 Use `set_target_position_after_gearbox()` when commanding positions at the
 load side of a gearbox.  Pass the desired output position and the gearbox ratio

--- a/demo.py
+++ b/demo.py
@@ -1,14 +1,26 @@
-from ethercat_servo import EthercatServo
+import argparse
+import os
 import time
 
-# Device name copied from get_adapter_name.py output
-IFNAME = r"\Device\NPF_{99F254B6-0FBF-4B4D-B9DB-F9CA300B4CCF}"  # TwinCAT-Intel PCI Ethernet Adapter (Gigabit)
-GEAR_RATIO = 30  # Example 30:1 planetary gearbox
+from ethercat_servo import EthercatServo
+from get_adapter_name import get_first_adapter
+
+# Environment variable to override the detected adapter name
+ENV_IFNAME = "ECAT_IFNAME"
+
+# Example 30:1 planetary gearbox
+GEAR_RATIO = 30
 
 
-def main():
-    # Use the selected Ethernet adapter for EtherCAT communication
-    servo = EthercatServo(ifname=IFNAME, slave_pos=0)
+def main(ifname: str | None = None) -> None:
+    """Run a small motion demo on the first EtherCAT slave."""
+
+    if ifname is None:
+        ifname = os.environ.get(ENV_IFNAME)
+    if ifname is None:
+        ifname = get_first_adapter()
+
+    servo = EthercatServo(ifname=ifname, slave_pos=0)
     servo.open()
     try:
         servo.set_mode(1)             # profile-position mode
@@ -24,4 +36,12 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Minimal EtherCAT servo demo")
+    parser.add_argument(
+        "-i",
+        "--ifname",
+        metavar="IFNAME",
+        help="Ethernet adapter name used for EtherCAT communication",
+    )
+    args = parser.parse_args()
+    main(args.ifname)


### PR DESCRIPTION
## Summary
- detect first adapter with `get_first_adapter()` and use it in the demo
- allow overriding adapter via env var `ECAT_IFNAME` or `--ifname` CLI flag
- document the new behaviour in the README

## Testing
- `python -m py_compile demo.py ethercat_servo.py get_adapter_name.py`
- `dotnet test CodexHardwareLoop/CodexHardwareLoop.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501c874eb48324813e78fe4c9a3c3d