### PR TITLE
Add Python cache dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ obj/
 TestResults/
 AllureReport/
 *.zip
+__pycache__/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- keep Python cache directories out of version control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501c80537c83248a7a8e70fc166c2e