### PR TITLE
Add customizable adapter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ To experiment with a simple graphical interface, launch `gui.py`. Use
 python gui.py --simulate
 ```
 
-By default the script uses the first network adapter returned by
-`get_first_adapter()` from `get_adapter_name.py`.  Use the optional
+By default the script uses the adapter returned by
+`get_adapter_name()` from `get_adapter_name.py`.  Use the optional
 `--backend` argument to select between the real servo (`hw`) and the simulator
 (`sim`).  The default is `hw`.  You can override the adapter name via the
 `ECAT_IFNAME` environment variable or with `--ifname IFNAME`.  Adjust the slave
 position in `demo.py` if needed.
+Pass ``"search"`` to ``get_adapter_name()`` to list available adapters and use
+the first one found.
 
 Use `set_target_position_after_gearbox()` when commanding positions at the
 load side of a gearbox.  Pass the desired output position and the gearbox ratio

--- a/demo.py
+++ b/demo.py
@@ -13,14 +13,14 @@ def import_backend(backend: str):
     if backend == "sim":
         from servo_simulator import ServoSimulator as EthercatServo
 
-        def get_first_adapter() -> str:
+        def get_adapter_name(search: str = "default") -> str:
             return "sim"
 
     else:
         from ethercat_servo import EthercatServo
-        from get_adapter_name import get_first_adapter
+        from get_adapter_name import get_adapter_name
 
-    return EthercatServo, get_first_adapter
+    return EthercatServo, get_adapter_name
 
 
 def main(ifname: str | None = None, backend: str | None = None) -> None:
@@ -29,12 +29,12 @@ def main(ifname: str | None = None, backend: str | None = None) -> None:
     if backend is None:
         backend = "sim" if os.getenv("SIMULATION") == "1" else "hw"
 
-    EthercatServo, get_first_adapter = import_backend(backend)
+    EthercatServo, get_adapter_name = import_backend(backend)
 
     if ifname is None:
         ifname = os.environ.get(ENV_IFNAME)
     if ifname is None:
-        ifname = get_first_adapter()
+        ifname = get_adapter_name()
 
     servo = EthercatServo(ifname=ifname, slave_pos=0)
     servo.open()

--- a/device_controller.py
+++ b/device_controller.py
@@ -20,8 +20,8 @@ class DeviceController:
             self.servo.open()
         else:
             from ethercat_servo import EthercatServo
-            from get_adapter_name import get_first_adapter
-            ifname = os.getenv("ECAT_IFNAME", get_first_adapter())
+            from get_adapter_name import get_adapter_name
+            ifname = os.getenv("ECAT_IFNAME", get_adapter_name())
             self.servo = EthercatServo(ifname=ifname)
             self.servo.open()
 

--- a/get_adapter_name.py
+++ b/get_adapter_name.py
@@ -9,6 +9,9 @@ Works with both PySOEM ≥1.0 (str fields) and earlier versions (bytes fields).
 from __future__ import annotations
 import pysoem
 
+# Default adapter name used when no search is performed
+IFNAME = r"\Device\NPF_{99F254B6-0FBF-4B4D-B9DB-F9CA300B4CCF}"
+
 
 def _to_str(value: str | bytes) -> str:
     """Convert bytes → str if needed (PySOEM ≤0.3) else return unchanged."""
@@ -21,6 +24,25 @@ def list_adapters() -> None:
         name = _to_str(ad.name)
         desc = _to_str(ad.desc)
         print(f"{name}  —  {desc}")
+
+
+def get_adapter_name(search: str = "default") -> str:
+    """Return the adapter name.
+
+    Parameters
+    ----------
+    search : str
+        Pass ``"search"`` to print all available adapters and return the
+        first suitable adapter.  Any other value (including ``"default"``)
+        returns :data:`IFNAME`.
+    """
+    if search == "search":
+        list_adapters()
+        try:
+            return get_first_adapter()
+        except RuntimeError:
+            return IFNAME
+    return IFNAME
 
 
 def get_first_adapter(exclude_loopback: bool = True) -> str:

--- a/gui.py
+++ b/gui.py
@@ -8,7 +8,7 @@ if os.getenv("SIMULATION") == "1":
 else:
     from ethercat_servo import EthercatServo
 
-from get_adapter_name import get_first_adapter
+from get_adapter_name import get_adapter_name
 
 # Indices of registers displayed in the GUI.  Each entry contains
 # (index, subindex, name, size_in_bytes).
@@ -116,7 +116,7 @@ def main(ifname=None, simulate=False):
     if ifname is None:
         ifname = os.environ.get("ECAT_IFNAME")
     if ifname is None:
-        ifname = get_first_adapter()
+        ifname = get_adapter_name()
 
     if simulate:
         servo = EthercatServo(ifname=ifname, slave_pos=0)


### PR DESCRIPTION
## Summary
- add default adapter constant and `get_adapter_name()` helper
- update demo, device controller and GUI to use the new helper
- document the new adapter mechanism in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685147eb18d883248dc3ffefb143f732